### PR TITLE
Make wkId nullable while reading it from json

### DIFF
--- a/lib/src/geometry/spatial_references.dart
+++ b/lib/src/geometry/spatial_references.dart
@@ -26,7 +26,7 @@ class SpatialReference {
     if (json == null) {
       return null;
     }
-    final int wkId = json['wkid'];
+    final int? wkId = json['wkid'];
     switch (wkId) {
       case 4326:
         return _wgs84;


### PR DESCRIPTION
When constructing SpatialReference from JSON, the wkId may returns NULL.