### PR TITLE
Adds feature table query method to map controller for iOS & Android

### DIFF
--- a/android/src/main/java/com/valentingrigorean/arcgis_maps_flutter/Convert.java
+++ b/android/src/main/java/com/valentingrigorean/arcgis_maps_flutter/Convert.java
@@ -20,6 +20,7 @@ import com.esri.arcgisruntime.arcgisservices.TimeAware;
 import com.esri.arcgisruntime.arcgisservices.TimeUnit;
 import com.esri.arcgisruntime.data.EditResult;
 import com.esri.arcgisruntime.data.FeatureEditResult;
+import com.esri.arcgisruntime.data.QueryParameters;
 import com.esri.arcgisruntime.data.TileCache;
 import com.esri.arcgisruntime.geometry.AngularUnit;
 import com.esri.arcgisruntime.geometry.AngularUnitId;
@@ -187,6 +188,68 @@ public class Convert {
         }
     }
 
+    public static QueryParameters.SpatialRelationship toSpatialRelationship(Object o) {
+        switch (toInt(o)) {
+            case -1:
+                return QueryParameters.SpatialRelationship.UNKNOWN;
+            case 0:
+                return QueryParameters.SpatialRelationship.RELATE;
+            case 1:
+                return QueryParameters.SpatialRelationship.EQUALS;
+            case 2:
+                return QueryParameters.SpatialRelationship.DISJOINT;
+            case 3:
+                return QueryParameters.SpatialRelationship.INTERSECTS;
+            case 4:
+                return QueryParameters.SpatialRelationship.TOUCHES;
+            case 5:
+                return QueryParameters.SpatialRelationship.CROSSES;
+            case 6:
+                return QueryParameters.SpatialRelationship.WITHIN;
+            case 7:
+                return QueryParameters.SpatialRelationship.CONTAINS;
+            case 8:
+                return QueryParameters.SpatialRelationship.OVERLAPS;
+            case 9:
+                return QueryParameters.SpatialRelationship.ENVELOPE_INTERSECTS;
+            case 10:
+                return QueryParameters.SpatialRelationship.INDEX_INTERSECTS;
+            default:
+                throw new IllegalStateException("Unexpected value: " + o);
+        }
+    }
+
+    public static int spatialRelationshipToJson(QueryParameters.SpatialRelationship spatialRelationship) {
+        switch (spatialRelationship) {
+            case UNKNOWN:
+                return -1;
+            case RELATE:
+                return 0;
+            case EQUALS:
+                return 1;
+            case DISJOINT:
+                return 2;
+            case INTERSECTS:
+                return 3;
+            case TOUCHES:
+                return 4;
+            case CROSSES:
+                return 5;
+            case WITHIN:
+                return 6;
+            case CONTAINS:
+                return 7;
+            case OVERLAPS:
+                return 8;
+            case ENVELOPE_INTERSECTS:
+                return 9;
+            case INDEX_INTERSECTS:
+                return 10;
+            default:
+                throw new IllegalStateException("Unexpected value: " + spatialRelationship);
+        }
+    }
+
     public static Style toScaleBarStyle(int rawValue) {
         switch (rawValue) {
             case 0:
@@ -317,6 +380,21 @@ public class Convert {
             e.printStackTrace();
         }
         return null;
+    }
+
+    @Nullable
+    public static Object geoElementToJson(GeoElement element) {
+
+        final Map<String, Object> attributes = new HashMap<>(element.getAttributes().size());
+        element.getAttributes().forEach((k, v) -> attributes.put(k, toFlutterFieldType(v)));
+
+        final Map<String, Object> elementData = new HashMap<>(2);
+
+        elementData.put("attributes", attributes);
+        if (element.getGeometry() != null)
+            elementData.put("geometry", geometryToJson(element.getGeometry()));
+
+        return elementData;
     }
 
     public static Point toPoint(Object o) {

--- a/ios/Classes/Convert/AGSEnum+Flutter.swift
+++ b/ios/Classes/Convert/AGSEnum+Flutter.swift
@@ -165,3 +165,68 @@ extension AGSAreaUnitID {
         }
     }
 }
+
+extension AGSSpatialRelationship {
+
+    static func fromFlutter(_ index: Int) -> AGSSpatialRelationship {
+        switch index {
+        case -1:
+            return .unknown
+        case 0:
+            return .relate
+        case 1:
+            return .equals
+        case 2:
+            return .disjoint
+        case 3:
+            return .intersects
+        case 4:
+            return .touches
+        case 5:
+            return .crosses
+        case 6:
+            return .within
+        case 7:
+            return .contains
+        case 8:
+            return .overlaps
+        case 9:
+            return .envelopeIntersects
+        case 10:
+            return .indexIntersects
+        default:
+            return .unknown
+        }
+    }
+
+    func toFlutter() -> Int {
+        switch self {
+        case .unknown:
+            return -1
+        case .relate:
+            return 0
+        case .equals:
+            return 1
+        case .disjoint:
+            return 2
+        case .intersects:
+            return 3
+        case .touches:
+            return 4
+        case .crosses:
+            return 5
+        case .within:
+            return 6
+        case .contains:
+            return 7
+        case .overlaps:
+            return 8
+        case .envelopeIntersects:
+            return 9
+        case .indexIntersects:
+            return 10
+        default:
+            return -1
+        }
+    }
+}

--- a/lib/arcgis_maps_flutter.dart
+++ b/lib/arcgis_maps_flutter.dart
@@ -56,6 +56,7 @@ part 'src/data/tile_cache.dart';
 part 'src/data/geodatabase.dart';
 part 'src/data/sync_model.dart';
 part 'src/data/tile_key.dart';
+part 'src/data/query_parameters.dart';
 
 part 'src/geometry/ags_polygon.dart';
 part 'src/geometry/ags_polyline.dart';

--- a/lib/src/data/query_parameters.dart
+++ b/lib/src/data/query_parameters.dart
@@ -1,0 +1,45 @@
+part of arcgis_maps_flutter;
+
+enum SpatialRelationship {
+  unknown(-1),
+  relate(0),
+  equals(1),
+  disjoint(2),
+  intersects(3),
+  touches(4),
+  crosses(5),
+  within(6),
+  contains(7),
+  overlaps(8),
+  envelopeIntersects(9),
+  indexIntersects(10);
+
+  const SpatialRelationship(this.value);
+
+  factory SpatialRelationship.fromValue(int value) {
+    return SpatialRelationship.values.firstWhere(
+          (e) => e.value == value,
+      orElse: () => SpatialRelationship.unknown,
+    );
+  }
+
+  final int value;
+}
+
+class QueryParameters {
+
+  QueryParameters({
+    this.spatialRelationship,
+  });
+
+  SpatialRelationship? spatialRelationship;
+
+  @override
+  String get type => "QueryParameters";
+
+  Object toJson() {
+    final json = <String, dynamic>{};
+    json['spatialRelationship'] = spatialRelationship?.value;
+    return json;
+  }
+}

--- a/lib/src/mapping/view/map/arcgis_map_controller.dart
+++ b/lib/src/mapping/view/map/arcgis_map_controller.dart
@@ -73,6 +73,23 @@ class ArcgisMapController {
     return layers;
   }
 
+  Future<List<GeoElement>> queryFeatureTableFromLayer({
+        required String layerName,
+        Geometry? geometry,
+        SpatialRelationship? spatialRelationship,
+        int? maxResults,
+        Map<String, dynamic>? queryValues,
+      }) async {
+    return ArcgisMapsFlutterPlatform.instance.queryFeatureTableFromLayer(
+      mapId: mapId,
+      layerName: layerName,
+      queryValues: queryValues,
+      geometry: geometry,
+      spatialRelationship: spatialRelationship,
+      maxResults: maxResults
+    );
+  }
+
   Future<List<LegendInfoResult>> getLegendInfosForLayers(
       Set<Layer> layers) async {
     var futures = <Future<List<LegendInfoResult>>>[];

--- a/lib/src/method_channel/map/arcgis_maps_flutter_platform.dart
+++ b/lib/src/method_channel/map/arcgis_maps_flutter_platform.dart
@@ -93,6 +93,20 @@ abstract class ArcgisMapsFlutterPlatform extends PlatformInterface {
         'getWanderExtentFactor() has not been implemented.');
   }
 
+  Future<List<GeoElement>> queryFeatureTableFromLayer(
+      {
+        required int mapId,
+        required String layerName,
+        Geometry? geometry,
+        SpatialRelationship? spatialRelationship,
+        int? maxResults,
+        Map<String, dynamic>? queryValues
+      }
+      ) {
+    throw UnimplementedError(
+        'selectFeatureById() has not been implemented.');
+  }
+
   Future<List<TimeAwareLayerInfo>> getTimeAwareLayerInfos(int mapId) {
     throw UnimplementedError(
         'getTimeAwareLayerInfos() has not been implemented.');

--- a/lib/src/method_channel/map/method_channel_arcgis_maps_flutter.dart
+++ b/lib/src/method_channel/map/method_channel_arcgis_maps_flutter.dart
@@ -228,6 +228,45 @@ class MethodChannelArcgisMapsFlutter extends ArcgisMapsFlutterPlatform {
   }
 
   @override
+  Future<List<GeoElement>> queryFeatureTableFromLayer(
+      {
+        required int mapId,
+        required String layerName,
+        Geometry? geometry,
+        SpatialRelationship? spatialRelationship,
+        int? maxResults,
+        Map<String, dynamic>? queryValues,
+      }) async {
+
+    queryValues ??= {};
+
+    queryValues["layerName"] = layerName;
+
+    if (geometry != null) {
+      queryValues["geometry"] = geometry.toJson();
+    }
+
+    if (spatialRelationship != null) {
+      queryValues["spatialRelationship"] = spatialRelationship.value;
+    }
+
+    if (maxResults != null) {
+      queryValues["maxResults"] = maxResults.toString();
+    }
+
+    final result = await channel(mapId).invokeListMethod(
+      'map#queryFeatureTableFromLayer',
+      queryValues,
+    );
+
+    return result
+        ?.map<GeoElement>((e) => GeoElement.fromJson(e))
+        .toList() ??
+        const [];
+
+  }
+
+  @override
   Future<List<TimeAwareLayerInfo>> getTimeAwareLayerInfos(int mapId) async {
     final result =
         await channel(mapId).invokeListMethod('map#getTimeAwareLayerInfos');


### PR DESCRIPTION
* Supports querying a feature table based on the corresponding layer's name, case insensitive. 
* Supports spatial queries by passing a geometry and spatial relationship.
* Additional query params can be passed via the queryValues param.
* Adds GeoElement & SpatialRelationship to JSON methods.