### PR TITLE
Add onLongPressEnd parameter to ArcgisMapView widget

### DIFF
--- a/android/src/main/java/com/valentingrigorean/arcgis_maps_flutter/geometry/GeometryEngineController.java
+++ b/android/src/main/java/com/valentingrigorean/arcgis_maps_flutter/geometry/GeometryEngineController.java
@@ -277,3 +277,4 @@ public class GeometryEngineController implements MethodChannel.MethodCallHandler
             result.success(Convert.geometryToJson(geometry.getExtent()));
         }
     }
+}

--- a/ios/Classes/Map/ArcgisMapController.swift
+++ b/ios/Classes/Map/ArcgisMapController.swift
@@ -828,6 +828,10 @@ extension ArcgisMapController: AGSGeoViewTouchDelegate {
         sendOnMapLongPress(screenPoint: screenPoint)
     }
 
+    public func geoView(_ geoView: AGSGeoView, didEndLongPressAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
+            sendOnMapLongPressEnd(screenPoint: screenPoint)
+        }
+
 
     private func identifyGraphicsOverlaysCallback(results: [AGSIdentifyGraphicsOverlayResult]?,
                                                   error: Error?) {
@@ -903,6 +907,12 @@ extension ArcgisMapController: AGSGeoViewTouchDelegate {
             channel.invokeMethod("map#onLongPress", arguments: ["screenPoint": screenPoint.toJSONFlutter(), "position": json])
         }
     }
+
+    private func sendOnMapLongPressEnd(screenPoint: CGPoint) {
+            if let json = mapView.screen(toLocation: screenPoint).toJSONFlutter() {
+                channel.invokeMethod("map#onLongPressEnd", arguments: ["screenPoint": screenPoint.toJSONFlutter(), "position": json])
+            }
+        }
 
     private func sendUserLocationTap() {
         channel.invokeMethod("map#onUserLocationTap", arguments: nil)

--- a/lib/src/mapping/view/map/arcgis_map_controller.dart
+++ b/lib/src/mapping/view/map/arcgis_map_controller.dart
@@ -313,6 +313,10 @@ class ArcgisMapController {
         (MapLongPressEvent e) =>
             _arcgisMapState.onLongPress(e.screenPoint, e.position));
 
+    ArcgisMapsFlutterPlatform.instance.onLongPressEnd(mapId: mapId).listen(
+            (MapLongPressEndEvent e) =>
+            _arcgisMapState.onLongPressEnd(e.screenPoint, e.position));
+
     ArcgisMapsFlutterPlatform.instance.onLayerLoad(mapId: mapId).listen(
         (LayerLoadedEvent e) =>
             _arcgisMapState.onLayerLoaded(e.value, e.error));

--- a/lib/src/mapping/view/map/arcgis_map_view.dart
+++ b/lib/src/mapping/view/map/arcgis_map_view.dart
@@ -84,6 +84,7 @@ class ArcgisMapView extends StatefulWidget {
     this.contentInsets = EdgeInsets.zero,
     this.onTap,
     this.onLongPress,
+    this.onLongPressEnd,
     this.onIdentifyLayer = const {},
     this.onIdentifyLayers,
     this.onUserLocationTap,
@@ -193,6 +194,8 @@ class ArcgisMapView extends StatefulWidget {
   final GestureCallback? onTap;
 
   final GestureCallback? onLongPress;
+
+  final GestureCallback? onLongPressEnd;
 
   /// Options to configure user interactions with the view.
   final InteractionOptions interactionOptions;
@@ -408,6 +411,13 @@ class _ArcgisMapViewState extends State<ArcgisMapView> {
     final onLongPress = widget.onLongPress;
     if (onLongPress != null) {
       onLongPress(screenPoint, position);
+    }
+  }
+
+  void onLongPressEnd(Offset screenPoint, AGSPoint position) {
+    final onLongPressEnd = widget.onLongPressEnd;
+    if (onLongPressEnd != null) {
+      onLongPressEnd(screenPoint, position);
     }
   }
 

--- a/lib/src/method_channel/map/arcgis_maps_flutter_platform.dart
+++ b/lib/src/method_channel/map/arcgis_maps_flutter_platform.dart
@@ -246,6 +246,11 @@ abstract class ArcgisMapsFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('onLongPress() has not been implemented.');
   }
 
+  /// A Map has been long tapped at a certain [LatLng] and the long tap has ended.
+  Stream<MapLongPressEndEvent> onLongPressEnd({required int mapId}) {
+    throw UnimplementedError('onLongPressEnd() has not been implemented.');
+  }
+
   Stream<UserLocationTapEvent> onUserLocationTap({required int mapId}) {
     throw UnimplementedError('onUserLocationTap() has not been implemented.');
   }

--- a/lib/src/method_channel/map/map_event.dart
+++ b/lib/src/method_channel/map/map_event.dart
@@ -118,6 +118,14 @@ class MapLongPressEvent extends _PositionedMapEvent<void> {
   }) : super(value: null);
 }
 
+class MapLongPressEndEvent extends _PositionedMapEvent<void> {
+  const MapLongPressEndEvent(
+      super.mapId, {
+        required super.screenPoint,
+        required super.position,
+      }) : super(value: null);
+}
+
 class ViewpointChangedEvent extends MapEvent<void> {
   const ViewpointChangedEvent(int mapId) : super(mapId, null);
 }

--- a/lib/src/method_channel/map/method_channel_arcgis_maps_flutter.dart
+++ b/lib/src/method_channel/map/method_channel_arcgis_maps_flutter.dart
@@ -484,6 +484,11 @@ class MethodChannelArcgisMapsFlutter extends ArcgisMapsFlutterPlatform {
   }
 
   @override
+  Stream<MapLongPressEndEvent> onLongPressEnd({required int mapId}) {
+    return _events(mapId).whereType<MapLongPressEndEvent>();
+  }
+
+  @override
   Stream<UserLocationTapEvent> onUserLocationTap({required int mapId}) {
     return _events(mapId).whereType<UserLocationTapEvent>();
   }
@@ -593,6 +598,18 @@ class MethodChannelArcgisMapsFlutter extends ArcgisMapsFlutterPlatform {
         AGSPoint position = AGSPoint.fromJson(args['position'])!;
         _mapEventStreamController.add(
           MapLongPressEvent(
+            mapId,
+            screenPoint: screenPoint,
+            position: position,
+          ),
+        );
+        break;
+      case 'map#onLongPressEnd':
+        final args = call.arguments;
+        final screenPoint = _fromJson(args['screenPoint']);
+        AGSPoint position = AGSPoint.fromJson(args['position'])!;
+        _mapEventStreamController.add(
+          MapLongPressEndEvent(
             mapId,
             screenPoint: screenPoint,
             position: position,


### PR DESCRIPTION
This PR exposes a parameter in the ArcgisMapView widget called onLongPressEnd. It allows for code to be run after a long press on a map ends. This is different than onLongPress: the code in onLongPressEnd will run after the user's finger is lifted from a long press whereas code in onLongPress will run as soon as the long press is detected by the system. 

For Android, this is done by leveraging [onUp](https://developers.arcgis.com/android/api-reference/reference/com/esri/arcgisruntime/mapping/view/DefaultMapViewOnTouchListener.html#onUp(android.view.MotionEvent)) from the ESRI ArcGIS Runtime SDK for Android. For iOS, it is done by leveraging [didEndLongPressAtScreenPoint](https://developers.arcgis.com/ios/api-reference/protocol_a_g_s_geo_view_touch_delegate-p.html#a295cdf0a1a7c8e759af01130d0d9d8ac) from the ESRI ArcGIS Runtime SDK for iOS.

This PR also adds the curly brace back into GeometryEngineController.java that went missing in the last commit (9796efd).